### PR TITLE
[FEAT](ui): add repost management options to BlogArticleProfileNoComment

### DIFF
--- a/src/feature/Blog/components/BlogComponents/BlogArticleProfile.tsx
+++ b/src/feature/Blog/components/BlogComponents/BlogArticleProfile.tsx
@@ -56,7 +56,7 @@ const BlogArticleProfile: React.FC<BlogProfileProps> = ({
   article,
   title,
   content,
-  isArticle,
+  isArticle, 
   isRepostedView = false,
 }) => {
   const { authUser, isLoggedIn } = useUser();


### PR DESCRIPTION
Added dropdown options for users to manage their own reposts from the simplified profile component. Users can now edit commentary, share, and delete their reposts when viewing them in their profile.

Key changes:
- Added repost detection for current user's reposts
- Implemented edit commentary, share, and delete options
- Added appropriate modals and confirmation dialogs
- Enhanced dropdown menu logic for repost management